### PR TITLE
Project structure refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ArgoCD external cluster EKS config provider for GKE (workload identity)
 
-The purpose of this application is to facilitate identity based (without use of any permanents credentials) authentication of EKS clusters in ArgoCD running on Google Kubernetes Engine (GKE) clusters with workload identity. 
+The purpose of this application is to facilitate identity based (without use of any permanents credentials) authentication of EKS clusters in ArgoCD running on Google Kubernetes Engine (GKE) clusters with workload identity.
 
 ## Table of Contents
 
@@ -17,20 +17,25 @@ The purpose of this application is to facilitate identity based (without use of 
 - [Additional resources](#additional-resources)
 
 ## Introduction
+
 A scenario this application covers is an ArgoCD instance running on GKE and using workload identity and Google Cloud -> AWS IAM role federation to authenticate EKS clusters without need of providing any kind of long term credentials. The program uses GKE/GCE provided OAuth token to assume AWS role and generate pre-signed URL for EKS authentication.
 
 ## Prerequisites
+
 1. A Google Cloud environment configured with IAM identity. This could be a VM instance using a service account identity or a GKE pod configured with GKE workload identity. In the case of ArgoCD this means having `argocd-server` and `argocd-application-controller` deployments using workload identity. Workload identity can be easily configured using the official workload identity [terraform module](https://registry.terraform.io/modules/terraform-google-modules/kubernetes-engine/google/latest/submodules/workload-identity).
 2. An AWS role that is configured to trust the GCP service account used in the environment running the program. In the case of ArgoCD these are the service accounts used by the `argocd-server` and `argocd-application-controller` deployments/pods. This involves setting up AWS IAM role trust policy for `sts:AssumeRoleWithWebIdentity` action specifying `accounts.google.com` federated principal (more documentation [here](https://gist.github.com/wvanderdeijl/c6a9a9f26149cea86039b3608e3556c1)).
 3. The IAM role from step 3. having appropriate permissions (policies attached) for EKS cluster(s) management.
 
 ## Getting started
+
 ### Installation
+
 Download precompiled binary for your platform from the repository' [releases page](https://github.com/zepellin/argocd-k8s-auth-gke-wli-eks/releases). In the case of ArgoCD the binary has to be available in the `argocd-server` and `argocd-application-controller` deployments/pods.
 
 The binary can be shipped via [custom ArgoCD images](https://argo-cd.readthedocs.io/en/stable/operator-manual/custom_tools/#byoi-build-your-own-image), or [added via volume mounts](https://argo-cd.readthedocs.io/en/stable/operator-manual/custom_tools/#adding-tools-via-volume-mounts) and placed in the `argocd-server` and `argocd-application-controller` deployments/pods.
 
 Example for [ArgoCD official Helm Chart](https://github.com/argoproj/argo-helm/blob/main/charts/argo-cd/values.yaml#L655-L675):
+
 ```yaml
 controller and server:
   ...
@@ -53,19 +58,25 @@ controller and server:
    - name: argo-k8s-auth-gke-wli-eks
      emptyDir: {}
 ```
+
 ### Usage
+
 The program takes following arguments:
 
-* **-rolearn**: The AWS IAM role ARN to assume (required).
-* **-cluster**: The name of the AWS EKS cluster for which you need credentials (required).
-* **-stsregion**: AWS STS region to which requests are made (optional, default: us-east-1).
+- **-rolearn**: The AWS IAM role ARN to assume (required).
+- **-cluster**: The name of the AWS EKS cluster for which you need credentials (required).
+- **-stsregion**: AWS STS region to which requests are made (optional, default: us-east-1).
 
 Example:
+
 ```bash
-$ k8s-auth-gke-wli-eks -rolearn "arn:aws:iam::123456789012:role/argocdrole" -cluster "my-eks-cluster-name" -stsregion "us-east-1"
+k8s-auth-gke-wli-eks -rolearn "arn:aws:iam::123456789012:role/argocdrole" -cluster "my-eks-cluster-name" -stsregion "us-east-1"
 ```
+
 ## ArgoCD Configuration
+
 Create a secret defining secret in your ArgoCD namespace where `data.config` is base64 encoded section as in following example.
+
 ```yaml
 apiVersion: v1
 kind: Secret
@@ -100,19 +111,23 @@ stringData:
 ```
 
 ## Features
-The output of the program is an [ExecCredential](https://kubernetes.io/docs/reference/config-api/client-authentication.v1beta1/#client-authentication-k8s-io-v1beta1-ExecCredential) object of the [client.authentication.k8s.io/v1beta1](https://kubernetes.io/docs/reference/config-api/client-authentication.v1beta1/) Kubernetes API that is consumed by ArgoCD when authenticating EKS cluster. 
+
+The output of the program is an [ExecCredential](https://kubernetes.io/docs/reference/config-api/client-authentication.v1beta1/#client-authentication-k8s-io-v1beta1-ExecCredential) object of the [client.authentication.k8s.io/v1beta1](https://kubernetes.io/docs/reference/config-api/client-authentication.v1beta1/) Kubernetes API that is consumed by ArgoCD when authenticating EKS cluster.
 
 ## Contributing
+
 If you'd like to contribute to this project, please follow the standard open-source contribution guidelines. Please report issues, submit feature requests, or create pull requests to improve the application.
 
 ## Additional resources
-* Terraform GKE Worload identity module: [terraform-google-workload-identity
-](https://registry.terraform.io/modules/terraform-google-modules/kubernetes-engine/google/latest/submodules/workload-identity)
-* Available keys for AWS web identity federation, for example of role trust with accounts.google.com. [AWS docs link](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_iam-condition-keys.html)
-* How to use trust policies with IAM roles, for ways to futher secure AWS trust policies. [AWS Blog](https://aws.amazon.com/es/blogs/security/how-to-use-trust-policies-with-iam-roles/)
+
+- Terraform GKE Worload identity module: [terraform-google-workload-identity](https://registry.terraform.io/modules/terraform-google-modules/kubernetes-engine/google/latest/submodules/workload-identity)
+- Available keys for AWS web identity federation, for example of role trust with accounts.google.com. [AWS docs link](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_iam-condition-keys.html)
+- How to use trust policies with IAM roles, for ways to futher secure AWS trust policies. [AWS Blog](https://aws.amazon.com/es/blogs/security/how-to-use-trust-policies-with-iam-roles/)
 
 ## Credits
-* Use of aws-sdk-go-v2 to get working EKS token: [Github aws-sdk-go-v2](https://github.com/aws/aws-sdk-go-v2/issues/1922)
+
+- Use of aws-sdk-go-v2 to get working EKS token: [Github aws-sdk-go-v2](https://github.com/aws/aws-sdk-go-v2/issues/1922)
 
 ## License
+
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,8 @@
 module argocd-k8s-auth-gke-wli-eks
 
-go 1.21
-toolchain go1.22.4
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	cloud.google.com/go/compute/metadata v0.2.3

--- a/main.go
+++ b/main.go
@@ -2,206 +2,105 @@ package main
 
 import (
 	"context"
-	"encoding/base64"
-	"encoding/json"
-	"flag"
 	"fmt"
-	"io"
 	"log/slog"
-	"net/http"
 	"os"
 	"time"
 
-	"cloud.google.com/go/compute/metadata"
-	"github.com/aws/aws-sdk-go-v2/aws"
-	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
-	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
-	"github.com/aws/aws-sdk-go-v2/service/sts"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clientauthv1beta1 "k8s.io/client-go/pkg/apis/clientauthentication/v1beta1"
+	"argocd-k8s-auth-gke-wli-eks/pkg/aws"
+	"argocd-k8s-auth-gke-wli-eks/pkg/config"
+	"argocd-k8s-auth-gke-wli-eks/pkg/gcp"
+	"argocd-k8s-auth-gke-wli-eks/pkg/k8s"
 )
 
 const (
-	eksClusterIdHeader = "x-k8s-aws-id" // Header name identifying EKS cluser in STS getCallerIdentity call
-	// The sts GetCallerIdentity request is valid for 15 minutes regardless of this parameters value after it has been
-	// signed, but we set this unused parameter to 60 for legacy reasons (we check for a value between 0 and 60 on the
-	// server side in 0.3.0 or earlier).  IT IS IGNORED.  If we can get STS to support x-amz-expires, then we should
-	// set this parameter to the actual expiration, and make it configurable.
-	requestPresignParam    = 60
-	presignedURLExpiration = 15 * time.Minute // The actual token expiration (presigned STS urls are valid for 15 minutes after timestamp in x-amz-date).
-	tokenV1Prefix          = "k8s-aws-v1."    // Prefix of a token in client.authentication.k8s.io/v1beta1 ExecCredential
+	presignedURLExpiration = 15 * time.Minute
 )
 
-var logger = slog.New(slog.NewJSONHandler(os.Stdout, nil))
-
-// Creates GCP metadata client
-func gcpMetadataClient() *metadata.Client {
-	c := metadata.NewClient(&http.Client{Timeout: 1 * time.Second})
-	return c
-}
-
-// Constucts AWs session identifier from GCP metadata infrmation.
-// This implementation uses concentration of  GCP project ID and machine hostname
-func createSessionIdentifier(c *metadata.Client) (string, error) {
-	projectId, err := c.ProjectID()
-	if err != nil {
-		logger.Error("Couldn't fetch ProjectId from GCP metadata server")
-		return "", err
-	}
-
-	hostname, err := c.Hostname()
-	if err != nil {
-		logger.Error("Couldn't fetch Hostname from GCP metadata server")
-		return "", err
-	}
-
-	return (fmt.Sprintf("%s-%s", projectId, hostname)[:32]), nil
-}
-
-// Retrieves GCE identity token (JWT) and retuens [customIdentityTokenRetriever] instance
-// containing the token. This is to be then used in [stscreds.NewWebIdentityRoleProvider]
-// function.
-func gcpRetrieveGCEVMToken(ctx context.Context) (customIdentityTokenRetriever, error) {
-	url := "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?format=full&audience=gcp"
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return customIdentityTokenRetriever{token: nil}, fmt.Errorf("http.NewRequest: %w", err)
-	}
-	req.Header.Set("Metadata-Flavor", "Google")
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return customIdentityTokenRetriever{token: nil}, fmt.Errorf("client.Do: %w", err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != 200 {
-		return customIdentityTokenRetriever{token: nil}, fmt.Errorf("status code %d", resp.StatusCode)
-	}
-	b, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return customIdentityTokenRetriever{token: nil}, fmt.Errorf("io.ReadAll: %w", err)
-	}
-	gcpMetadataToken := customIdentityTokenRetriever{token: b}
-	return gcpMetadataToken, nil
-}
-
-func main() {
-	awsAssumeRoleArn := flag.String("rolearn", "", "AWS role ARN to assume (required)")
-	eksClusterName := flag.String("cluster", "", "AWS cluster name for which we create credentials (required)")
-	stsRegion := flag.String("stsregion", "us-east-1", "AWS STS region to which requests are made (optional)")
-
-	flag.Parse()
-	if *awsAssumeRoleArn == "" || *eksClusterName == "" {
-		flag.Usage()
-		os.Exit(1)
-	}
-
-	ctx := context.Background()
-
-	sessionIdentifier, err := createSessionIdentifier(gcpMetadataClient())
-	if err != nil {
-		logger.Error("Failed to create session identifier from GCP metadata, %s" + err.Error())
-		os.Exit(1)
-	}
-
-	assumeRoleCfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(*stsRegion))
-	if err != nil {
-		logger.Error("failed to load default AWS config, %s" + err.Error())
-		os.Exit(1)
-	}
-
-	gcpMetadataToken, err := gcpRetrieveGCEVMToken(ctx)
-	if err != nil {
-		logger.Error("Failed to get JWT token from GCP metadata, %s" + err.Error())
-		os.Exit(1)
-	}
-
-	stsAssumeClient := sts.NewFromConfig(assumeRoleCfg)
-	awsCredsCache := aws.NewCredentialsCache(stscreds.NewWebIdentityRoleProvider(
-		stsAssumeClient,
-		*awsAssumeRoleArn,
-		gcpMetadataToken,
-		func(o *stscreds.WebIdentityRoleOptions) {
-			o.RoleSessionName = sessionIdentifier
-		}),
-	)
-
-	awsCredentials, err := awsCredsCache.Retrieve(ctx)
-	if err != nil {
-		logger.Error("Couldn't retrieve AWS credentials %s", err)
-		os.Exit(1)
-	}
-
-	eksSignerCfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(*stsRegion),
-		config.WithCredentialsProvider(credentials.StaticCredentialsProvider{
-			Value: awsCredentials,
-		}),
-	)
-	if err != nil {
-		logger.Error("Couldn't load AWS config using retrieved credentials %s", err)
-		os.Exit(1)
-	}
-
-	stsClient := sts.NewFromConfig(eksSignerCfg)
-
-	presignclient := sts.NewPresignClient(stsClient)
-	presignedURLString, err := presignclient.PresignGetCallerIdentity(ctx, &sts.GetCallerIdentityInput{}, func(opt *sts.PresignOptions) {
-		opt.Presigner = newCustomHTTPPresignerV4(opt.Presigner, map[string]string{
-			eksClusterIdHeader: *eksClusterName,
-			"X-Amz-Expires":    "60",
-		})
-	})
-
-	token := tokenV1Prefix + base64.RawURLEncoding.EncodeToString([]byte(presignedURLString.URL))
-	// Set token expiration to 1 minute before the presigned URL expires for some cushion
-	tokenExpiration := time.Now().Local().Add(presignedURLExpiration - 1*time.Minute)
-	_, _ = fmt.Fprint(os.Stdout, formatJSON(token, tokenExpiration))
-}
-
-func formatJSON(token string, expiration time.Time) string {
-	expirationTimestamp := metav1.NewTime(expiration)
-	execInput := &clientauthv1beta1.ExecCredential{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "client.authentication.k8s.io/v1beta1",
-			Kind:       "ExecCredential",
-		},
-		Status: &clientauthv1beta1.ExecCredentialStatus{
-			ExpirationTimestamp: &expirationTimestamp,
-			Token:               token,
-		},
-	}
-	enc, _ := json.Marshal(execInput)
-	return string(enc)
-}
-
-type customIdentityTokenRetriever struct {
+// gcpTokenRetriever implements aws.TokenRetriever interface
+type gcpTokenRetriever struct {
 	token []byte
 }
 
-func (obj customIdentityTokenRetriever) GetIdentityToken() ([]byte, error) {
-	return obj.token, nil
+func (t *gcpTokenRetriever) GetIdentityToken() ([]byte, error) {
+	return t.token, nil
 }
 
-type customHTTPPresignerV4 struct {
-	client  sts.HTTPPresignerV4
-	headers map[string]string
-}
+var logger = slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+	Level:     slog.LevelInfo,
+	AddSource: true,
+}))
 
-func newCustomHTTPPresignerV4(client sts.HTTPPresignerV4, headers map[string]string) sts.HTTPPresignerV4 {
-	return &customHTTPPresignerV4{
-		client:  client,
-		headers: headers,
+func run(ctx context.Context) error {
+	// Load configuration
+	cfg := config.NewConfig()
+	if err := cfg.LoadFromFlags(); err != nil {
+		return fmt.Errorf("failed to load configuration: %w", err)
 	}
+
+	// Initialize GCP metadata client
+	metadataProvider := gcp.NewMetadataProvider(cfg.HTTPTimeout)
+
+	// Get session identifier
+	sessionID, err := metadataProvider.CreateSessionIdentifier(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create session identifier: %w", err)
+	}
+
+	logger.Info("created session identifier", "sessionID", sessionID)
+
+	// Get GCP identity token
+	gcpToken, err := metadataProvider.GetIdentityToken(ctx, "gcp")
+	if err != nil {
+		return fmt.Errorf("failed to get GCP identity token: %w", err)
+	}
+
+	// Create token retriever for AWS authentication
+	tokenRetriever := &gcpTokenRetriever{token: gcpToken}
+
+	// Initialize AWS authenticator
+	awsAuth, err := aws.NewAuthenticator(ctx, cfg.AWSRoleARN, sessionID, cfg.STSRegion, tokenRetriever)
+	if err != nil {
+		return fmt.Errorf("failed to create AWS authenticator: %w", err)
+	}
+
+	// Get AWS credentials
+	awsCreds, err := awsAuth.GetCredentials(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get AWS credentials: %w", err)
+	}
+
+	logger.Info("retrieved AWS credentials")
+
+	// Get presigned URL
+	presignedURL, err := awsAuth.GetPresignedCallerIdentityURL(ctx, cfg.EKSClusterName, awsCreds)
+	if err != nil {
+		return fmt.Errorf("failed to get presigned URL: %w", err)
+	}
+
+	// Generate Kubernetes ExecCredential
+	credGen := k8s.NewCredentialGenerator()
+	execCred, err := credGen.GenerateExecCredential(
+		presignedURL,
+		time.Now().Add(presignedURLExpiration),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to generate exec credential: %w", err)
+	}
+
+	// Write the credential to stdout
+	if _, err := fmt.Fprint(os.Stdout, string(execCred)); err != nil {
+		return fmt.Errorf("failed to write exec credential: %w", err)
+	}
+
+	return nil
 }
 
-func (p *customHTTPPresignerV4) PresignHTTP(
-	ctx context.Context, credentials aws.Credentials, r *http.Request,
-	payloadHash string, service string, region string, signingTime time.Time,
-	optFns ...func(*v4.SignerOptions),
-) (url string, signedHeader http.Header, err error) {
-	for key, val := range p.headers {
-		r.Header.Add(key, val)
+func main() {
+	ctx := context.Background()
+
+	if err := run(ctx); err != nil {
+		logger.Error("program failed", "error", err)
+		os.Exit(1)
 	}
-	return p.client.PresignHTTP(ctx, credentials, r, payloadHash, service, region, signingTime, optFns...)
 }

--- a/pkg/aws/auth.go
+++ b/pkg/aws/auth.go
@@ -1,0 +1,134 @@
+// Package aws provides AWS authentication and credential management functionality
+package aws
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+)
+
+// TokenRetriever defines the interface for retrieving identity tokens
+type TokenRetriever interface {
+	GetIdentityToken() ([]byte, error)
+}
+
+// STSClient wraps STS functionality for better testing
+type STSClient interface {
+	GetCallerIdentity(context.Context, *sts.GetCallerIdentityInput, ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error)
+}
+
+// AWSAuthenticator handles AWS authentication and credential management
+type AWSAuthenticator struct {
+	stsClient      STSClient
+	tokenRetriever TokenRetriever
+	roleARN        string
+	sessionName    string
+	region         string
+}
+
+// NewAuthenticator creates a new AWS authenticator
+func NewAuthenticator(ctx context.Context, roleARN, sessionName, region string, tokenRetriever TokenRetriever) (*AWSAuthenticator, error) {
+	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
+	if err != nil {
+		return nil, fmt.Errorf("failed to load AWS config: %w", err)
+	}
+
+	stsClient := sts.NewFromConfig(cfg)
+
+	return &AWSAuthenticator{
+		stsClient:      stsClient,
+		tokenRetriever: tokenRetriever,
+		roleARN:        roleARN,
+		sessionName:    sessionName,
+		region:         region,
+	}, nil
+}
+
+// GetCredentials retrieves AWS credentials using web identity federation
+func (a *AWSAuthenticator) GetCredentials(ctx context.Context) (aws.Credentials, error) {
+	provider := stscreds.NewWebIdentityRoleProvider(
+		a.stsClient.(*sts.Client),
+		a.roleARN,
+		a.tokenRetriever,
+		func(o *stscreds.WebIdentityRoleOptions) {
+			o.RoleSessionName = a.sessionName
+		},
+	)
+
+	credCache := aws.NewCredentialsCache(provider)
+	creds, err := credCache.Retrieve(ctx)
+	if err != nil {
+		return aws.Credentials{}, fmt.Errorf("failed to retrieve AWS credentials: %w", err)
+	}
+
+	return creds, nil
+}
+
+// CustomPresigner adds custom headers to STS presigned URLs
+type CustomPresigner struct {
+	client  sts.HTTPPresignerV4
+	headers map[string]string
+}
+
+// NewCustomPresigner creates a new custom presigner with specified headers
+func NewCustomPresigner(client sts.HTTPPresignerV4, headers map[string]string) sts.HTTPPresignerV4 {
+	return &CustomPresigner{
+		client:  client,
+		headers: headers,
+	}
+}
+
+// PresignHTTP implements the HTTPPresignerV4 interface with custom header support
+func (p *CustomPresigner) PresignHTTP(
+	ctx context.Context,
+	credentials aws.Credentials,
+	r *http.Request,
+	payloadHash string,
+	service string,
+	region string,
+	signingTime time.Time,
+	optFns ...func(*v4.SignerOptions),
+) (string, http.Header, error) {
+	for key, val := range p.headers {
+		r.Header.Add(key, val)
+	}
+	return p.client.PresignHTTP(ctx, credentials, r, payloadHash, service, region, signingTime, optFns...)
+}
+
+// GetPresignedCallerIdentityURL generates a presigned URL for GetCallerIdentity
+func (a *AWSAuthenticator) GetPresignedCallerIdentityURL(ctx context.Context, clusterName string, creds aws.Credentials) (string, error) {
+	cfg, err := config.LoadDefaultConfig(ctx,
+		config.WithRegion(a.region),
+		config.WithCredentialsProvider(credentials.StaticCredentialsProvider{
+			Value: creds,
+		}),
+	)
+	if err != nil {
+		return "", fmt.Errorf("failed to load AWS config with credentials: %w", err)
+	}
+
+	stsClient := sts.NewFromConfig(cfg)
+	presignClient := sts.NewPresignClient(stsClient)
+
+	presignedURL, err := presignClient.PresignGetCallerIdentity(ctx,
+		&sts.GetCallerIdentityInput{},
+		func(opt *sts.PresignOptions) {
+			opt.Presigner = NewCustomPresigner(opt.Presigner, map[string]string{
+				"x-k8s-aws-id":  clusterName,
+				"X-Amz-Expires": "60",
+			})
+		})
+	if err != nil {
+		return "", fmt.Errorf("failed to presign GetCallerIdentity request: %w", err)
+	}
+
+	return presignedURL.URL, nil
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,74 @@
+// Package config provides configuration structures and loading mechanisms
+package config
+
+import (
+	"flag"
+	"fmt"
+	"time"
+)
+
+const (
+	// DefaultSTSRegion is the default AWS STS region
+	DefaultSTSRegion = "us-east-1"
+	// DefaultTokenExpiryMinutes is the default token expiration time in minutes
+	DefaultTokenExpiryMinutes = 15
+	// DefaultHTTPTimeout is the default timeout for HTTP requests
+	DefaultHTTPTimeout = 10 * time.Second
+	// TokenV1Prefix is the prefix for v1 tokens
+	TokenV1Prefix = "k8s-aws-v1."
+	// HeaderEKSClusterID is the header name for EKS cluster identification
+	HeaderEKSClusterID = "x-k8s-aws-id"
+	// HeaderExpires is the header name for expiration
+	HeaderExpires = "X-Amz-Expires"
+	// RequestPresignParam is the presign parameter value (legacy support)
+	RequestPresignParam = "60"
+)
+
+// Config holds the application configuration
+type Config struct {
+	// AWS configuration
+	AWSRoleARN     string
+	EKSClusterName string
+	STSRegion      string
+
+	// Token configuration
+	TokenExpiration time.Duration
+
+	// HTTP configuration
+	HTTPTimeout time.Duration
+}
+
+// NewConfig creates a new configuration instance with defaults
+func NewConfig() *Config {
+	return &Config{
+		STSRegion:       DefaultSTSRegion,
+		TokenExpiration: DefaultTokenExpiryMinutes * time.Minute,
+		HTTPTimeout:     DefaultHTTPTimeout,
+	}
+}
+
+// LoadFromFlags loads configuration from command line flags
+func (c *Config) LoadFromFlags() error {
+	flag.StringVar(&c.AWSRoleARN, "rolearn", "", "AWS role ARN to assume (required)")
+	flag.StringVar(&c.EKSClusterName, "cluster", "", "AWS cluster name for which we create credentials (required)")
+	flag.StringVar(&c.STSRegion, "stsregion", DefaultSTSRegion, "AWS STS region to which requests are made (optional)")
+
+	flag.Parse()
+
+	if err := c.validate(); err != nil {
+		return fmt.Errorf("invalid configuration: %w", err)
+	}
+
+	return nil
+}
+
+// validate checks if the configuration is valid
+func (c *Config) validate() error {
+	if c.AWSRoleARN == "" {
+		return fmt.Errorf("AWS role ARN is required")
+	}
+	if c.EKSClusterName == "" {
+		return fmt.Errorf("EKS cluster name is required")
+	}
+	return nil
+}

--- a/pkg/gcp/metadata.go
+++ b/pkg/gcp/metadata.go
@@ -1,0 +1,99 @@
+// Package gcp provides Google Cloud Platform related functionality
+package gcp
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"cloud.google.com/go/compute/metadata"
+)
+
+// MetadataProvider defines the interface for GCP metadata operations
+type MetadataProvider interface {
+	ProjectID(ctx context.Context) (string, error)
+	Hostname(ctx context.Context) (string, error)
+	GetIdentityToken(ctx context.Context, audience string) ([]byte, error)
+	CreateSessionIdentifier(ctx context.Context) (string, error)
+}
+
+// GCPMetadata implements the MetadataProvider interface
+type GCPMetadata struct {
+	client *metadata.Client
+}
+
+// NewMetadataProvider creates a new GCP metadata provider
+func NewMetadataProvider(timeout time.Duration) MetadataProvider {
+	return &GCPMetadata{
+		client: metadata.NewClient(&http.Client{Timeout: timeout}),
+	}
+}
+
+// ProjectID retrieves the GCP project ID from metadata
+func (g *GCPMetadata) ProjectID(ctx context.Context) (string, error) {
+	projectID, err := g.client.ProjectID()
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch ProjectID from GCP metadata: %w", err)
+	}
+	return projectID, nil
+}
+
+// Hostname retrieves the instance hostname from metadata
+func (g *GCPMetadata) Hostname(ctx context.Context) (string, error) {
+	hostname, err := g.client.Hostname()
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch Hostname from GCP metadata: %w", err)
+	}
+	return hostname, nil
+}
+
+// GetIdentityToken retrieves a GCP identity token
+func (g *GCPMetadata) GetIdentityToken(ctx context.Context, audience string) ([]byte, error) {
+	url := fmt.Sprintf("http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?format=full&audience=%s", audience)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create identity token request: %w", err)
+	}
+
+	req.Header.Set("Metadata-Flavor", "Google")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve identity token: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code retrieving identity token: %d", resp.StatusCode)
+	}
+
+	token, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read identity token response: %w", err)
+	}
+
+	return token, nil
+}
+
+// CreateSessionIdentifier creates a unique session identifier from GCP metadata
+func (g *GCPMetadata) CreateSessionIdentifier(ctx context.Context) (string, error) {
+	projectID, err := g.ProjectID(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	hostname, err := g.Hostname(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	// Ensure the session identifier doesn't exceed 32 characters
+	sessionID := fmt.Sprintf("%s-%s", projectID, hostname)
+	if len(sessionID) > 32 {
+		sessionID = sessionID[:32]
+	}
+
+	return sessionID, nil
+}

--- a/pkg/k8s/credentials.go
+++ b/pkg/k8s/credentials.go
@@ -1,0 +1,51 @@
+// Package k8s provides Kubernetes credential handling functionality
+package k8s
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientauthv1beta1 "k8s.io/client-go/pkg/apis/clientauthentication/v1beta1"
+)
+
+const (
+	// TokenV1Prefix is the prefix for v1 tokens
+	TokenV1Prefix = "k8s-aws-v1."
+	// TokenExpirationBuffer is the buffer time before the token actually expires
+	TokenExpirationBuffer = 1 * time.Minute
+)
+
+// CredentialGenerator handles generation of Kubernetes ExecCredentials
+type CredentialGenerator struct{}
+
+// NewCredentialGenerator creates a new credential generator
+func NewCredentialGenerator() *CredentialGenerator {
+	return &CredentialGenerator{}
+}
+
+// GenerateExecCredential creates a Kubernetes ExecCredential from a presigned URL
+func (g *CredentialGenerator) GenerateExecCredential(presignedURL string, expiration time.Time) ([]byte, error) {
+	// Create the token by concatenating the prefix and base64 encoded URL
+	token := TokenV1Prefix + base64.RawURLEncoding.EncodeToString([]byte(presignedURL))
+
+	// Adjust expiration time to include buffer
+	adjustedExpiration := expiration.Add(-TokenExpirationBuffer)
+	expirationTimestamp := metav1.NewTime(adjustedExpiration)
+
+	// Create the ExecCredential object
+	execCred := &clientauthv1beta1.ExecCredential{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "client.authentication.k8s.io/v1beta1",
+			Kind:       "ExecCredential",
+		},
+		Status: &clientauthv1beta1.ExecCredentialStatus{
+			ExpirationTimestamp: &expirationTimestamp,
+			Token:               token,
+		},
+	}
+
+	// Marshal to JSON
+	return json.Marshal(execCred)
+}


### PR DESCRIPTION
This pull request includes significant changes to improve the structure and functionality of the `argocd-k8s-auth-gke-wli-eks` application. The changes include code refactoring, modularization, and updates to dependencies. The most important changes are categorized below:

### Code Refactoring and Modularization:
* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L5-L206): Refactored to modularize the code by moving AWS, GCP, and configuration-related logic into separate packages (`pkg/aws`, `pkg/gcp`, `pkg/config`). Simplified the main function to improve readability and maintainability.
* [`pkg/aws/auth.go`](diffhunk://#diff-4e88eabe2221067babf7dbd5e11ed6b30f134a36127884424d3fda8a86094c7fR1-R134): Created a new package for AWS authentication and credential management, including a new `AWSAuthenticator` class and related methods.
* [`pkg/config/config.go`](diffhunk://#diff-a3d824da3c42420cd5cbb0a4a2c0e7b5bfddd819652788a0596d195dc6e31fa5R1-R74): Created a new package for configuration management, including a `Config` struct and methods to load and validate configuration from command line flags.

### Dependency Updates:
* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R5): Updated Go version from `1.21` to `1.23.0` and toolchain version to `1.23.6`.

### Documentation Improvements:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R20-R38): Added missing newlines for better readability and updated formatting in multiple sections, including Introduction, Prerequisites, Installation, Usage, ArgoCD Configuration, Features, Contributing, and Additional Resources. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R20-R38) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R61-R79) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R114-R132)