### PR TITLE
Implement global logger

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,3 +23,4 @@ jobs:
         goarch: ${{ matrix.goarch }}
         binary_name: "k8s-auth-gke-wli-eks"
         compress_assets: "OFF"
+        goversion: "./go.mod"

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -1,0 +1,86 @@
+package logger
+
+import (
+	"flag"
+	"fmt"
+
+	"k8s.io/klog/v2"
+)
+
+var (
+	// Global logger configuration
+	logLevel  int
+	logToFile string
+)
+
+// Config holds logger configuration
+type Config struct {
+	Level     int    // Log level (0-5)
+	ToFile    string // Log file path (empty for stderr)
+	Verbosity int    // Verbosity level for debug logs
+}
+
+// Initialize sets up the global logger with the given configuration
+func Initialize(config Config) error {
+	logLevel = config.Level
+	logToFile = config.ToFile
+
+	// Create a new flagset for klog
+	fs := flag.NewFlagSet("logger", flag.ContinueOnError)
+	klog.InitFlags(fs)
+
+	// Set klog specific flags
+	if err := fs.Set("v", fmt.Sprintf("%d", config.Verbosity)); err != nil {
+		return fmt.Errorf("failed to set verbosity: %v", err)
+	}
+
+	if logToFile != "" {
+		if err := fs.Set("log_file", logToFile); err != nil {
+			return fmt.Errorf("failed to set log file: %v", err)
+		}
+	}
+
+	return nil
+}
+
+// Error logs an error message with optional format arguments
+func Error(format string, args ...interface{}) {
+	klog.ErrorS(nil, fmt.Sprintf(format, args...))
+}
+
+// Errorf logs an error message with error and optional format arguments
+func Errorf(err error, format string, args ...interface{}) {
+	klog.ErrorS(err, fmt.Sprintf(format, args...))
+}
+
+// Warning logs a warning message with optional format arguments
+func Warning(format string, args ...interface{}) {
+	klog.Warning(fmt.Sprintf(format, args...))
+}
+
+// Info logs an info message with optional format arguments
+func Info(format string, args ...interface{}) {
+	klog.Info(fmt.Sprintf(format, args...))
+}
+
+// Infof logs an info message with optional key-value pairs
+func Infof(msg string, keysAndValues ...interface{}) {
+	klog.InfoS(msg, keysAndValues...)
+}
+
+// Debug logs a debug message if the verbosity level is high enough
+func Debug(format string, args ...interface{}) {
+	if klog.V(1).Enabled() {
+		klog.InfoS("DEBUG", "msg", fmt.Sprintf(format, args...))
+	}
+}
+
+// V returns true if the verbosity level is at least the requested level
+func V(level int) bool {
+	return klog.V(klog.Level(level)).Enabled()
+}
+
+// Flush ensures all pending log writes are completed
+func Flush() {
+	klog.Flush()
+}

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -1,0 +1,93 @@
+package logger
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestInitialize(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  Config
+		wantErr bool
+	}{
+		{
+			name: "basic configuration",
+			config: Config{
+				Level:     1,
+				Verbosity: 1,
+			},
+			wantErr: false,
+		},
+		{
+			name: "with file output",
+			config: Config{
+				Level:     2,
+				ToFile:    "/tmp/test.log",
+				Verbosity: 2,
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := Initialize(tt.config)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Initialize() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestLoggingFunctions(t *testing.T) {
+	// Initialize with test configuration
+	config := Config{
+		Level:     1,
+		Verbosity: 1,
+	}
+	if err := Initialize(config); err != nil {
+		t.Fatalf("Failed to initialize logger: %v", err)
+	}
+
+	// Test each logging function
+	// Note: These tests only verify that the functions don't panic
+	// since klog writes to stderr by default
+	t.Run("Error", func(t *testing.T) {
+		Error("test error message")
+	})
+
+	t.Run("Errorf", func(t *testing.T) {
+		Errorf(errors.New("test error"), "error occurred: %s", "test")
+	})
+
+	t.Run("Warning", func(t *testing.T) {
+		Warning("test warning message")
+	})
+
+	t.Run("Info", func(t *testing.T) {
+		Info("test info message")
+	})
+
+	t.Run("Infof", func(t *testing.T) {
+		Infof("test info message", "key1", "value1", "key2", "value2")
+	})
+
+	t.Run("Debug", func(t *testing.T) {
+		Debug("test debug message")
+	})
+
+	t.Run("V", func(t *testing.T) {
+		if !V(1) {
+			t.Error("Expected V(1) to return true with verbosity level 1")
+		}
+		if V(2) {
+			t.Error("Expected V(2) to return false with verbosity level 1")
+		}
+	})
+
+	// Test Flush
+	t.Run("Flush", func(t *testing.T) {
+		Flush()
+	})
+}


### PR DESCRIPTION
This pull request introduces a new logging system and updates the configuration structure to support it. The changes include the removal of the old logging system, the addition of a new logger package, and updates to the configuration to support log verbosity and file output.

### Logging System Update:

* **New Logger Package**: Added a new `logger` package to handle logging with support for verbosity levels and optional file output. (`pkg/logger/logger.go`, `pkg/logger/logger_test.go`) [[1]](diffhunk://#diff-c1dc2eb1e149a1dc7ecd5cb474e167fb456eb7ad0ea0256cf62fba693a89af79R1-R86) [[2]](diffhunk://#diff-1b8d9e7644b6bb4b1cbd02d902261663a31e2f4792231472ee673265132a6913R1-R93)
* **Logger Initialization**: Replaced the old logging initialization with the new logger's `Initialize` method and updated the logging calls accordingly. (`main.go`) [[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L53-R44) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L74-R62) [[3]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L126-R123)

### Configuration Changes:

* **Configuration Structure**: Updated the `Config` struct to include `LogVerbosity` and `LogToFile` fields instead of `LogLevel`. (`pkg/config/config.go`) [[1]](diffhunk://#diff-a3d824da3c42420cd5cbb0a4a2c0e7b5bfddd819652788a0596d195dc6e31fa5L30-R31) [[2]](diffhunk://#diff-a3d824da3c42420cd5cbb0a4a2c0e7b5bfddd819652788a0596d195dc6e31fa5L50-R52)
* **Flag Parsing**: Modified the flag parsing to accept the new logging configuration options. (`pkg/config/config.go`) [[1]](diffhunk://#diff-a3d824da3c42420cd5cbb0a4a2c0e7b5bfddd819652788a0596d195dc6e31fa5L59-R62) [[2]](diffhunk://#diff-a3d824da3c42420cd5cbb0a4a2c0e7b5bfddd819652788a0596d195dc6e31fa5L76-R81)

### Miscellaneous:

* **Removed Unused Imports**: Removed the unused `slog` import from `main.go`. (`main.go`)
* **GitHub Actions**: Added `goversion` to the release workflow configuration. (`.github/workflows/release.yaml`)