### PR TITLE
Implement response credentials caching

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,12 +21,10 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.11.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.20.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.23.4 // indirect
-	golang.org/x/oauth2 v0.26.0 // indirect
 	golang.org/x/sys v0.28.0 // indirect
 )
 
 require (
-	cloud.google.com/go/compute v1.14.0 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.27.11
 	github.com/aws/smithy-go v1.20.2 // indirect
 	github.com/go-logr/logr v1.4.1 // indirect
@@ -41,7 +39,7 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/apimachinery v0.30.2
 	k8s.io/client-go v0.30.2
-	k8s.io/klog/v2 v2.120.1 // indirect
+	k8s.io/klog/v2 v2.120.1
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,3 @@
-cloud.google.com/go/compute v1.14.0 h1:hfm2+FfxVmnRlh6LpB7cg1ZNU+5edAHmW679JePztk0=
-cloud.google.com/go/compute v1.14.0/go.mod h1:YfLtxrj9sU4Yxv+sXzZkyPjEyPBZfXHUvjxega5vAdo=
-cloud.google.com/go/compute/metadata v0.2.3 h1:mg4jlk7mCAj6xXp9UJ4fjI9VUI5rubuGBW5aJ7UnBMY=
-cloud.google.com/go/compute/metadata v0.2.3/go.mod h1:VAV5nSsACxMJvgaAuX6Pk2AawlZn8kiOGuCv6gTkwuA=
-cloud.google.com/go/compute/metadata v0.3.0/go.mod h1:zFmK7XCadkQkj6TtorcaGlCW1hT1fIilQDwofLpJ20k=
 cloud.google.com/go/compute/metadata v0.6.0 h1:A6hENjEsCDtC1k8byVsgwvVcioamEHvZ4j01OwKxG9I=
 cloud.google.com/go/compute/metadata v0.6.0/go.mod h1:FjyFAW1MW0C203CEOMDTu3Dk1FlqW3Rga40jzHL4hfg=
 github.com/aws/aws-sdk-go-v2 v1.26.1 h1:5554eUqIYVWpU0YmeeYZ0wU64H2VLBs8TlhRB2L+EkA=

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -1,0 +1,138 @@
+// Package cache provides credential caching functionality
+package cache
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"argocd-k8s-auth-gke-wli-eks/pkg/logger"
+)
+
+const (
+	// minValidityPeriod is the minimum time remaining before a cached credential is considered invalid
+	minValidityPeriod = 5 * time.Minute
+)
+
+// CacheKey represents the unique identifier for cached credentials
+type CacheKey struct {
+	AWSRoleARN     string `json:"aws_role_arn"`
+	EKSClusterName string `json:"eks_cluster_name"`
+	STSRegion      string `json:"sts_region"`
+}
+
+// CacheEntry represents a cached credential
+type CacheEntry struct {
+	ExecCredential []byte    `json:"exec_credential"`
+	ExpirationTime time.Time `json:"expiration_time"`
+}
+
+// Cache handles credential caching operations
+type Cache struct {
+	cacheDir string
+}
+
+// NewCache creates a new cache instance
+func NewCache() (*Cache, error) {
+	var cacheDir string
+	var err error
+
+	// Try user home directory first
+	homeDir, err := os.UserHomeDir()
+	if err == nil {
+		cacheDir = filepath.Join(homeDir, ".kube", "cache", "argocd-k8s-auth-gke-wli-eks")
+		if err := os.MkdirAll(cacheDir, 0700); err == nil {
+			logger.Debug("using cache directory: %s", cacheDir)
+			return &Cache{cacheDir: cacheDir}, nil
+		}
+		logger.Warning("failed to create cache directory in home directory: %v", err)
+	} else {
+		logger.Warning("failed to get user home directory: %v", err)
+	}
+
+	// If home directory fails, try system temporary directory
+	cacheDir, err = os.UserCacheDir()
+	if err == nil {
+		cacheDir = filepath.Join(cacheDir, "argocd-k8s-auth-gke-wli-eks")
+		if err := os.MkdirAll(cacheDir, 0700); err == nil {
+			logger.Debug("using cache directory: %s", cacheDir)
+			return &Cache{cacheDir: cacheDir}, nil
+		}
+		logger.Warning("failed to create cache directory in user cache directory: %v", err)
+
+	} else {
+		logger.Warning("failed to get user cache directory: %v", err)
+	}
+
+	// If both fail, try system temporary directory
+	cacheDir = os.TempDir()
+	cacheDir = filepath.Join(cacheDir, "argocd-k8s-auth-gke-wli-eks")
+	if err := os.MkdirAll(cacheDir, 0700); err == nil {
+		logger.Debug("using cache directory: %s", cacheDir)
+		return &Cache{cacheDir: cacheDir}, nil
+	}
+	logger.Warning("failed to create cache directory in temporary directory: %v", err)
+
+	return nil, fmt.Errorf("failed to create cache directory in any known location")
+}
+
+// Get retrieves cached credentials if they exist and are still valid
+func (c *Cache) Get(key CacheKey) ([]byte, bool) {
+	cacheFile := c.getCacheFilePath(key)
+
+	data, err := os.ReadFile(cacheFile)
+	if err != nil {
+		logger.Debug("no cache file found at %s", cacheFile)
+		return nil, false
+	}
+
+	var entry CacheEntry
+	if err := json.Unmarshal(data, &entry); err != nil {
+		logger.Debug("failed to unmarshal cache entry: %v", err)
+		return nil, false
+	}
+
+	// Check if the cached credential is still valid (has more than minValidityPeriod until expiration)
+	if time.Until(entry.ExpirationTime) < minValidityPeriod {
+		logger.Debug("cached credential is expired or will expire soon")
+		return nil, false
+	}
+
+	logger.Debug("using cached credential (expires in %v)", time.Until(entry.ExpirationTime))
+	return entry.ExecCredential, true
+}
+
+// Put stores credentials in the cache
+func (c *Cache) Put(key CacheKey, execCredential []byte, expirationTime time.Time) error {
+	entry := CacheEntry{
+		ExecCredential: execCredential,
+		ExpirationTime: expirationTime,
+	}
+
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return fmt.Errorf("failed to marshal cache entry: %w", err)
+	}
+
+	cacheFile := c.getCacheFilePath(key)
+	if err := os.WriteFile(cacheFile, data, 0600); err != nil {
+		return fmt.Errorf("failed to write cache file: %w", err)
+	}
+
+	logger.Debug("stored credential in cache (expires at %v)", expirationTime)
+	return nil
+}
+
+// getCacheFilePath returns the path to the cache file for the given key
+func (c *Cache) getCacheFilePath(key CacheKey) string {
+	// Create a unique filename based on the key components
+	// Replace special characters with underscores to ensure valid filename
+	sanitizedRole := strings.ReplaceAll(strings.ReplaceAll(key.AWSRoleARN, "/", "_"), ":", "_")
+	sanitizedCluster := strings.ReplaceAll(key.EKSClusterName, "/", "_")
+	sanitizedRegion := strings.ReplaceAll(key.STSRegion, "/", "_")
+	filename := fmt.Sprintf("%s_%s_%s.json", sanitizedRole, sanitizedCluster, sanitizedRegion)
+	return filepath.Join(c.cacheDir, filename)
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -43,6 +43,7 @@ type Config struct {
 
 	// Runtime configuration
 	HybridMode bool // When true, allows running outside GCP with fallback mechanisms
+	Cache      bool // When true, enables credential caching
 }
 
 // NewConfig creates a new configuration instance with defaults
@@ -64,6 +65,7 @@ func (c *Config) LoadFromFlags() error {
 	flag.StringVar(&c.EKSClusterName, "cluster", "", "AWS cluster name for which we create credentials (required)")
 	flag.StringVar(&c.STSRegion, "stsregion", DefaultSTSRegion, "AWS STS region to which requests are made (optional)")
 	flag.BoolVar(&c.HybridMode, "hybrid", false, "Enable hybrid mode to run outside GCP with fallback mechanisms")
+	flag.BoolVar(&c.Cache, "cache", false, "Enable credential caching")
 
 	flag.Parse()
 


### PR DESCRIPTION
This pull request introduces credential caching functionality to the `argocd-k8s-auth-gke-wli-eks` project. The most important changes include adding a new cache package, modifying the `main.go` file to integrate caching, and updating the configuration to support caching.

Credential caching functionality:

* [`pkg/cache/cache.go`](diffhunk://#diff-964e351ee2375d359c78d69e514c4edc42577219761c4475f391ed2daf715e51R1-R138): Added a new `cache` package that provides credential caching functionality, including defining `CacheKey` and `CacheEntry` types, and methods for creating a cache, retrieving cached credentials, and storing credentials in the cache.

Integration of caching in the main application:

* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R47-R75): Modified the `run` function to initialize the cache, check for cached credentials, and store credentials in the cache if caching is enabled. [[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R47-R75) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R133-R139)

Configuration updates:

* [`pkg/config/config.go`](diffhunk://#diff-a3d824da3c42420cd5cbb0a4a2c0e7b5bfddd819652788a0596d195dc6e31fa5R46): Added a new `Cache` field to the `Config` struct and updated the `LoadFromFlags` function to include a flag for enabling credential caching. [[1]](diffhunk://#diff-a3d824da3c42420cd5cbb0a4a2c0e7b5bfddd819652788a0596d195dc6e31fa5R46) [[2]](diffhunk://#diff-a3d824da3c42420cd5cbb0a4a2c0e7b5bfddd819652788a0596d195dc6e31fa5R68)

Other changes:

* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R10-R18): Updated the import statements to include the new `cache` package and changed the `presignedURLExpiration` constant to 30 minutes.
* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L24-L29): Removed unused dependencies and updated the `klog/v2` dependency to be direct. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L24-L29) [[2]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L44-R42)