### PR TITLE
Use slog for logging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -87,7 +87,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	k8s.io/apimachinery v0.32.2
 	k8s.io/client-go v0.32.2
-	k8s.io/klog/v2 v2.130.1
+	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 // indirect
 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect

--- a/main.go
+++ b/main.go
@@ -42,7 +42,6 @@ func run(ctx context.Context) error {
 	}); err != nil {
 		return fmt.Errorf("failed to initialize logger: %w", err)
 	}
-	defer logger.Flush()
 
 	// Initialize cache if enabled
 	var credCache *cache.Cache

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -5,7 +5,16 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"argocd-k8s-auth-gke-wli-eks/pkg/logger"
 )
+
+func init() {
+	// Initialize logger with debug level for tests
+	if err := logger.Initialize(logger.Config{Level: 2, Verbosity: 1}); err != nil {
+		panic(err)
+	}
+}
 
 func TestNewCache(t *testing.T) {
 	tests := []struct {

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -1,16 +1,13 @@
 package logger
 
 import (
-	"flag"
 	"fmt"
-
-	"k8s.io/klog/v2"
+	"log/slog"
+	"os"
 )
 
 var (
-	// Global logger configuration
-	logLevel  int
-	logToFile string
+	logger *slog.Logger
 )
 
 // Config holds logger configuration
@@ -22,65 +19,95 @@ type Config struct {
 
 // Initialize sets up the global logger with the given configuration
 func Initialize(config Config) error {
-	logLevel = config.Level
-	logToFile = config.ToFile
+	var w *os.File
+	var err error
 
-	// Create a new flagset for klog
-	fs := flag.NewFlagSet("logger", flag.ContinueOnError)
-	klog.InitFlags(fs)
-
-	// Set klog specific flags
-	if err := fs.Set("v", fmt.Sprintf("%d", config.Verbosity)); err != nil {
-		return fmt.Errorf("failed to set verbosity: %v", err)
-	}
-
-	if logToFile != "" {
-		if err := fs.Set("log_file", logToFile); err != nil {
-			return fmt.Errorf("failed to set log file: %v", err)
+	if config.ToFile != "" {
+		w, err = os.OpenFile(config.ToFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+		if err != nil {
+			return fmt.Errorf("failed to open log file: %v", err)
 		}
+	} else {
+		w = os.Stderr
 	}
+
+	// Convert level to slog.Level
+	var level slog.Level
+	switch {
+	case config.Level <= 0:
+		level = slog.LevelError
+	case config.Level == 1:
+		level = slog.LevelWarn
+	case config.Level == 2:
+		level = slog.LevelInfo
+	default:
+		level = slog.LevelDebug
+	}
+
+	opts := &slog.HandlerOptions{
+		Level: level,
+	}
+
+	handler := slog.NewJSONHandler(w, opts)
+	logger = slog.New(handler)
+	slog.SetDefault(logger)
 
 	return nil
 }
 
 // Error logs an error message with optional format arguments
 func Error(format string, args ...interface{}) {
-	klog.ErrorS(nil, fmt.Sprintf(format, args...))
+	msg := fmt.Sprintf(format, args...)
+	logger.Error(msg)
 }
 
 // Errorf logs an error message with error and optional format arguments
 func Errorf(err error, format string, args ...interface{}) {
-	klog.ErrorS(err, fmt.Sprintf(format, args...))
+	msg := fmt.Sprintf(format, args...)
+	logger.Error(msg, "error", err)
 }
 
 // Warning logs a warning message with optional format arguments
 func Warning(format string, args ...interface{}) {
-	klog.Warning(fmt.Sprintf(format, args...))
+	msg := fmt.Sprintf(format, args...)
+	logger.Warn(msg)
 }
 
 // Info logs an info message with optional format arguments
 func Info(format string, args ...interface{}) {
-	klog.Info(fmt.Sprintf(format, args...))
+	msg := fmt.Sprintf(format, args...)
+	logger.Info(msg)
 }
 
 // Infof logs an info message with optional key-value pairs
 func Infof(msg string, keysAndValues ...interface{}) {
-	klog.InfoS(msg, keysAndValues...)
+	logger.Info(msg, keysAndValues...)
 }
 
 // Debug logs a debug message if the verbosity level is high enough
 func Debug(format string, args ...interface{}) {
-	if klog.V(1).Enabled() {
-		klog.InfoS("DEBUG", "msg", fmt.Sprintf(format, args...))
-	}
+	msg := fmt.Sprintf(format, args...)
+	logger.Debug(msg)
 }
 
 // V returns true if the verbosity level is at least the requested level
 func V(level int) bool {
-	return klog.V(klog.Level(level)).Enabled()
+	// Convert level to slog.Level for comparison
+	var slogLevel slog.Level
+	switch level {
+	case 0:
+		slogLevel = slog.LevelError
+	case 1:
+		slogLevel = slog.LevelWarn
+	case 2:
+		slogLevel = slog.LevelInfo
+	default:
+		slogLevel = slog.LevelDebug
+	}
+	return logger.Enabled(nil, slogLevel)
 }
 
 // Flush ensures all pending log writes are completed
 func Flush() {
-	klog.Flush()
+	// slog handles flushing automatically
 }

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -107,7 +107,3 @@ func V(level int) bool {
 	return logger.Enabled(nil, slogLevel)
 }
 
-// Flush ensures all pending log writes are completed
-func Flush() {
-	// slog handles flushing automatically
-}

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -1,11 +1,37 @@
 package logger
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
+	"log/slog"
+	"os"
+	"strings"
 	"testing"
 )
 
+type testBuffer struct {
+	buf bytes.Buffer
+}
+
+func (b *testBuffer) Write(p []byte) (n int, err error) {
+	return b.buf.Write(p)
+}
+
+func (b *testBuffer) String() string {
+	return b.buf.String()
+}
+
+type logEntry struct {
+	Level string `json:"level"`
+	Msg   string `json:"msg"`
+	Error string `json:"error,omitempty"`
+	Time  string `json:"time"`
+}
+
 func TestInitialize(t *testing.T) {
+	tempDir := t.TempDir()
+
 	tests := []struct {
 		name    string
 		config  Config
@@ -23,7 +49,7 @@ func TestInitialize(t *testing.T) {
 			name: "with file output",
 			config: Config{
 				Level:     2,
-				ToFile:    "/tmp/test.log",
+				ToFile:    tempDir + "/test.log",
 				Verbosity: 2,
 			},
 			wantErr: false,
@@ -36,58 +62,127 @@ func TestInitialize(t *testing.T) {
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Initialize() error = %v, wantErr %v", err, tt.wantErr)
 			}
+
+			if tt.config.ToFile != "" {
+				if _, err := os.Stat(tt.config.ToFile); os.IsNotExist(err) {
+					t.Errorf("Expected log file %s to exist", tt.config.ToFile)
+				}
+			}
 		})
 	}
 }
 
 func TestLoggingFunctions(t *testing.T) {
-	// Initialize with test configuration
-	config := Config{
-		Level:     1,
-		Verbosity: 1,
+	buf := &testBuffer{}
+	handler := slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	logger = slog.New(handler)
+
+	tests := []struct {
+		name      string
+		logFunc   func()
+		wantLevel string
+		wantMsg   string
+		wantErr   string
+	}{
+		{
+			name:      "Error",
+			logFunc:   func() { Error("test error message") },
+			wantLevel: "ERROR",
+			wantMsg:   "test error message",
+		},
+		{
+			name:      "Errorf",
+			logFunc:   func() { Errorf(errors.New("test error"), "error occurred: %s", "test") },
+			wantLevel: "ERROR",
+			wantMsg:   "error occurred: test",
+			wantErr:   "test error",
+		},
+		{
+			name:      "Warning",
+			logFunc:   func() { Warning("test warning message") },
+			wantLevel: "WARN",
+			wantMsg:   "test warning message",
+		},
+		{
+			name:      "Info",
+			logFunc:   func() { Info("test info message") },
+			wantLevel: "INFO",
+			wantMsg:   "test info message",
+		},
+		{
+			name:      "Debug",
+			logFunc:   func() { Debug("test debug message") },
+			wantLevel: "DEBUG",
+			wantMsg:   "test debug message",
+		},
 	}
-	if err := Initialize(config); err != nil {
-		t.Fatalf("Failed to initialize logger: %v", err)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf.buf.Reset()
+			tt.logFunc()
+
+			var entry logEntry
+			if err := json.Unmarshal(buf.buf.Bytes(), &entry); err != nil {
+				t.Fatalf("Failed to parse log entry: %v", err)
+			}
+
+			if entry.Level != tt.wantLevel {
+				t.Errorf("got level %q, want %q", entry.Level, tt.wantLevel)
+			}
+
+			if entry.Msg != tt.wantMsg {
+				t.Errorf("got message %q, want %q", entry.Msg, tt.wantMsg)
+			}
+
+			if tt.wantErr != "" && !strings.Contains(entry.Error, tt.wantErr) {
+				t.Errorf("got error %q, want to contain %q", entry.Error, tt.wantErr)
+			}
+		})
 	}
 
-	// Test each logging function
-	// Note: These tests only verify that the functions don't panic
-	// since klog writes to stderr by default
-	t.Run("Error", func(t *testing.T) {
-		Error("test error message")
-	})
-
-	t.Run("Errorf", func(t *testing.T) {
-		Errorf(errors.New("test error"), "error occurred: %s", "test")
-	})
-
-	t.Run("Warning", func(t *testing.T) {
-		Warning("test warning message")
-	})
-
-	t.Run("Info", func(t *testing.T) {
-		Info("test info message")
-	})
-
+	// Test Infof separately as it has a different structure
 	t.Run("Infof", func(t *testing.T) {
-		Infof("test info message", "key1", "value1", "key2", "value2")
-	})
+		buf.buf.Reset()
+		Infof("test message", "key1", "value1")
 
-	t.Run("Debug", func(t *testing.T) {
-		Debug("test debug message")
-	})
-
-	t.Run("V", func(t *testing.T) {
-		if !V(1) {
-			t.Error("Expected V(1) to return true with verbosity level 1")
+		var entry map[string]interface{}
+		if err := json.Unmarshal(buf.buf.Bytes(), &entry); err != nil {
+			t.Fatalf("Failed to parse log entry: %v", err)
 		}
-		if V(2) {
-			t.Error("Expected V(2) to return false with verbosity level 1")
+
+		if entry["level"] != "INFO" {
+			t.Errorf("got level %v, want INFO", entry["level"])
+		}
+
+		if entry["msg"] != "test message" {
+			t.Errorf("got message %v, want 'test message'", entry["msg"])
+		}
+
+		if entry["key1"] != "value1" {
+			t.Errorf("got key1=%v, want 'value1'", entry["key1"])
 		}
 	})
 
-	// Test Flush
-	t.Run("Flush", func(t *testing.T) {
-		Flush()
+	// Test V function
+	t.Run("V level tests", func(t *testing.T) {
+		tests := []struct {
+			level    int
+			config   Config
+			expected bool
+		}{
+			{level: 0, config: Config{Level: 0}, expected: true},  // ERROR
+			{level: 1, config: Config{Level: 1}, expected: true},  // WARN
+			{level: 2, config: Config{Level: 1}, expected: false}, // INFO vs WARN
+			{level: 3, config: Config{Level: 2}, expected: false}, // DEBUG vs INFO
+		}
+
+		for _, tt := range tests {
+			Initialize(tt.config)
+			if got := V(tt.level); got != tt.expected {
+				t.Errorf("V(%d) with level %d = %v; want %v",
+					tt.level, tt.config.Level, got, tt.expected)
+			}
+		}
 	})
 }


### PR DESCRIPTION
This pull request introduces significant changes to the logging system, replacing the `klog` library with the `slog` library. The changes include updates to the logger initialization, logging functions, and associated tests.

Key changes include:

### Logger Initialization and Configuration:
* Replaced `klog` with `slog` for logging, updating the `Initialize` function to configure `slog` based on the provided configuration. (`pkg/logger/logger.go` - [[1]](diffhunk://#diff-c1dc2eb1e149a1dc7ecd5cb474e167fb456eb7ad0ea0256cf62fba693a89af79L4-R10) [[2]](diffhunk://#diff-c1dc2eb1e149a1dc7ecd5cb474e167fb456eb7ad0ea0256cf62fba693a89af79L25-R112)

### Logging Functions:
* Updated logging functions (`Error`, `Errorf`, `Warning`, `Info`, `Infof`, `Debug`, `V`, `Flush`) to use the new `slog` library. (`pkg/logger/logger.go` - [pkg/logger/logger.goL4-R10](diffhunk://#diff-c1dc2eb1e149a1dc7ecd5cb474e167fb456eb7ad0ea0256cf62fba693a89af79L4-R10))

### Tests:
* Added new tests for the `slog` implementation, including checks for log file creation and log message verification. (`pkg/logger/logger_test.go` - [[1]](diffhunk://#diff-1b8d9e7644b6bb4b1cbd02d902261663a31e2f4792231472ee673265132a6913R4-R34) [[2]](diffhunk://#diff-1b8d9e7644b6bb4b1cbd02d902261663a31e2f4792231472ee673265132a6913L26-R52) [[3]](diffhunk://#diff-1b8d9e7644b6bb4b1cbd02d902261663a31e2f4792231472ee673265132a6913R65-R186)
* Initialized the logger with debug level for tests in `pkg/cache/cache_test.go`. (`pkg/cache/cache_test.go` - [pkg/cache/cache_test.goR8-R18](diffhunk://#diff-3e99be25ef623d0bc22234a878bef63a1fef2029a18d5b35f9079537e9f59ebeR8-R18))

### Dependencies:
* Marked `k8s.io/klog/v2` as an indirect dependency in `go.mod`. (`go.mod` - [go.modL90-R90](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L90-R90))