### PR TITLE
Reduce lifetime of execCredential

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	presignedURLExpiration = 30 * time.Minute
+	presignedURLExpiration = 15 * time.Minute
 )
 
 // gcpTokenRetriever implements aws.TokenRetriever interface


### PR DESCRIPTION
This pull request includes a minor change to the `main.go` file. The change reduces the `presignedURLExpiration` constant from 30 minutes to 15 minutes to adjust the expiration duration for presigned URLs.

* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L18-R18): Updated the `presignedURLExpiration` constant to 15 minutes.