### PR TITLE
Fix: URL signing of correct headers

### DIFF
--- a/pkg/aws/aws_test.go
+++ b/pkg/aws/aws_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
 	"testing"
+	"time"
 
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
@@ -276,7 +276,7 @@ func TestGetPresignedCallerIdentityURL(t *testing.T) {
 				return
 			}
 
-			url, err := auth.GetPresignedCallerIdentityURL(context.Background(), tt.clusterName, creds)
+			url, err := auth.GetPresignedCallerIdentityURL(context.Background(), tt.clusterName, creds, time.Hour)
 			if tt.wantErr {
 				if err == nil {
 					t.Error("GetPresignedCallerIdentityURL() expected error, got nil")
@@ -289,9 +289,6 @@ func TestGetPresignedCallerIdentityURL(t *testing.T) {
 			}
 			if url == "" {
 				t.Error("GetPresignedCallerIdentityURL() returned empty URL")
-			}
-			if !strings.Contains(url, tt.clusterName) {
-				t.Errorf("GetPresignedCallerIdentityURL() URL does not contain cluster name, got %v", url)
 			}
 		})
 	}

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -11,7 +11,7 @@ import (
 
 func init() {
 	// Initialize logger with debug level for tests
-	if err := logger.Initialize(logger.Config{Level: 2, Verbosity: 1}); err != nil {
+	if err := logger.Initialize(logger.Config{Verbosity: 1}); err != nil {
 		panic(err)
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -59,7 +59,7 @@ func NewConfig() *Config {
 
 // LoadFromFlags loads configuration from command line flags
 func (c *Config) LoadFromFlags() error {
-	flag.IntVar(&c.LogVerbosity, "v", 0, "Log verbosity level (0-5)")
+	flag.IntVar(&c.LogVerbosity, "v", 0, "Log verbosity level (0-3)")
 	flag.StringVar(&c.LogToFile, "log-file", "", "Path to log file (empty for stderr)")
 	flag.StringVar(&c.AWSRoleARN, "rolearn", "", "AWS role ARN to assume (required)")
 	flag.StringVar(&c.EKSClusterName, "cluster", "", "AWS cluster name for which we create credentials (required)")
@@ -79,8 +79,8 @@ func (c *Config) LoadFromFlags() error {
 // validate checks if the configuration is valid
 func (c *Config) validate() error {
 	// Validate log verbosity
-	if c.LogVerbosity < 0 || c.LogVerbosity > 5 {
-		return fmt.Errorf("invalid log verbosity: %d (must be between 0 and 5)", c.LogVerbosity)
+	if c.LogVerbosity < 0 || c.LogVerbosity > 3 {
+		return fmt.Errorf("invalid log verbosity: %d (must be between 0 and 3)", c.LogVerbosity)
 	}
 
 	if c.AWSRoleARN == "" {

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -12,7 +12,6 @@ var (
 
 // Config holds logger configuration
 type Config struct {
-	Level     int    // Log level (0-5)
 	ToFile    string // Log file path (empty for stderr)
 	Verbosity int    // Verbosity level for debug logs
 }
@@ -34,14 +33,16 @@ func Initialize(config Config) error {
 	// Convert level to slog.Level
 	var level slog.Level
 	switch {
-	case config.Level <= 0:
+	case config.Verbosity <= 0:
 		level = slog.LevelError
-	case config.Level == 1:
+	case config.Verbosity == 1:
 		level = slog.LevelWarn
-	case config.Level == 2:
+	case config.Verbosity == 2:
 		level = slog.LevelInfo
-	default:
+	case config.Verbosity == 3:
 		level = slog.LevelDebug
+	default:
+		level = slog.LevelError
 	}
 
 	opts := &slog.HandlerOptions{
@@ -89,21 +90,3 @@ func Debug(format string, args ...interface{}) {
 	msg := fmt.Sprintf(format, args...)
 	logger.Debug(msg)
 }
-
-// V returns true if the verbosity level is at least the requested level
-func V(level int) bool {
-	// Convert level to slog.Level for comparison
-	var slogLevel slog.Level
-	switch level {
-	case 0:
-		slogLevel = slog.LevelError
-	case 1:
-		slogLevel = slog.LevelWarn
-	case 2:
-		slogLevel = slog.LevelInfo
-	default:
-		slogLevel = slog.LevelDebug
-	}
-	return logger.Enabled(nil, slogLevel)
-}
-

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -40,7 +40,6 @@ func TestInitialize(t *testing.T) {
 		{
 			name: "basic configuration",
 			config: Config{
-				Level:     1,
 				Verbosity: 1,
 			},
 			wantErr: false,
@@ -48,7 +47,6 @@ func TestInitialize(t *testing.T) {
 		{
 			name: "with file output",
 			config: Config{
-				Level:     2,
 				ToFile:    tempDir + "/test.log",
 				Verbosity: 2,
 			},
@@ -161,28 +159,6 @@ func TestLoggingFunctions(t *testing.T) {
 
 		if entry["key1"] != "value1" {
 			t.Errorf("got key1=%v, want 'value1'", entry["key1"])
-		}
-	})
-
-	// Test V function
-	t.Run("V level tests", func(t *testing.T) {
-		tests := []struct {
-			level    int
-			config   Config
-			expected bool
-		}{
-			{level: 0, config: Config{Level: 0}, expected: true},  // ERROR
-			{level: 1, config: Config{Level: 1}, expected: true},  // WARN
-			{level: 2, config: Config{Level: 1}, expected: false}, // INFO vs WARN
-			{level: 3, config: Config{Level: 2}, expected: false}, // DEBUG vs INFO
-		}
-
-		for _, tt := range tests {
-			Initialize(tt.config)
-			if got := V(tt.level); got != tt.expected {
-				t.Errorf("V(%d) with level %d = %v; want %v",
-					tt.level, tt.config.Level, got, tt.expected)
-			}
 		}
 	})
 }


### PR DESCRIPTION
This pull request introduces several changes to improve configuration flexibility, enhance logging, and add custom presigning capabilities for AWS STS presigned URLs. The most significant updates include refactoring the logger configuration to simplify verbosity levels, introducing a custom presigner for STS presigned URLs, and modifying the handling of presigned URL expiration.

### Configuration and Logging Updates:
* Removed the `Level` field from the logger configuration and replaced it with a more streamlined `Verbosity` field, reducing the verbosity range from 0-5 to 0-3. This change simplifies log level management and aligns verbosity with actual log output levels. (`pkg/logger/logger.go` [[1]](diffhunk://#diff-c1dc2eb1e149a1dc7ecd5cb474e167fb456eb7ad0ea0256cf62fba693a89af79L15) [[2]](diffhunk://#diff-c1dc2eb1e149a1dc7ecd5cb474e167fb456eb7ad0ea0256cf62fba693a89af79L37-R45) [[3]](diffhunk://#diff-c1dc2eb1e149a1dc7ecd5cb474e167fb456eb7ad0ea0256cf62fba693a89af79L92-L109); `pkg/config/config.go` [[4]](diffhunk://#diff-a3d824da3c42420cd5cbb0a4a2c0e7b5bfddd819652788a0596d195dc6e31fa5L62-R62) [[5]](diffhunk://#diff-a3d824da3c42420cd5cbb0a4a2c0e7b5bfddd819652788a0596d195dc6e31fa5L82-R83)
* Updated tests to reflect the removal of the `Level` field and the simplification of verbosity levels. (`pkg/logger/logger_test.go` [[1]](diffhunk://#diff-1b8d9e7644b6bb4b1cbd02d902261663a31e2f4792231472ee673265132a6913L43-L51) [[2]](diffhunk://#diff-1b8d9e7644b6bb4b1cbd02d902261663a31e2f4792231472ee673265132a6913L166-L187)

### AWS STS Presigned URL Enhancements:
* Added a `CustomPresigner` type to allow custom headers in STS presigned URLs, such as `EKSClusterID` and `Expires`. This enables more flexible URL generation for EKS cluster authentication. (`pkg/aws/aws.go` [[1]](diffhunk://#diff-557e359d6147fd859c120871f3c4b242f8781a32fb05b6a343978ff33c3b8e2fR39-R69) [[2]](diffhunk://#diff-557e359d6147fd859c120871f3c4b242f8781a32fb05b6a343978ff33c3b8e2fL120-R174)
* Modified the `GetPresignedCallerIdentityURL` function to accept a custom expiration duration and integrate the new `CustomPresigner`. (`pkg/aws/aws.go` [[1]](diffhunk://#diff-557e359d6147fd859c120871f3c4b242f8781a32fb05b6a343978ff33c3b8e2fL102-R138) [[2]](diffhunk://#diff-557e359d6147fd859c120871f3c4b242f8781a32fb05b6a343978ff33c3b8e2fL120-R174)

### Code Refactoring and Cleanup:
* Moved the creation of the cache key earlier in the `run` function to streamline cache initialization logic. (`main.go` [[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L39-R51) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L55-L62) [[3]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R72)
* Updated the default presigned URL expiration to use a configurable value (`DefaultTokenExpiryMinutes`) instead of a hardcoded 15 minutes. (`main.go` [main.goL18-R18](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L18-R18))

### Test Updates:
* Updated test cases for `GetPresignedCallerIdentityURL` to include the new expiration parameter and removed assertions on URL query parameters, as they are now handled via headers. (`pkg/aws/aws_test.go` [[1]](diffhunk://#diff-9d8f88ab7ec37b93cf0ebd8331c5094b144af4f60e34bcf51ef10e67c32483e3L279-R279) [[2]](diffhunk://#diff-9d8f88ab7ec37b93cf0ebd8331c5094b144af4f60e34bcf51ef10e67c32483e3L293-L295)
* Adjusted logger tests to align with the removal of the `Level` field and the simplification of verbosity levels. (`pkg/logger/logger_test.go` [[1]](diffhunk://#diff-1b8d9e7644b6bb4b1cbd02d902261663a31e2f4792231472ee673265132a6913L43-L51) [[2]](diffhunk://#diff-1b8d9e7644b6bb4b1cbd02d902261663a31e2f4792231472ee673265132a6913L166-L187)

These changes collectively enhance the flexibility, maintainability, and functionality of the codebase, particularly in the areas of logging and AWS STS presigned URL generation.